### PR TITLE
Harden anime scrapers against 403 responses

### DIFF
--- a/dist/anims/otakudesu/parsers/OtakudesuParser.js
+++ b/dist/anims/otakudesu/parsers/OtakudesuParser.js
@@ -11,12 +11,21 @@ class OtakudesuParser extends OtakudesuParserExtra_1.default {
         const httpOptions = {
             origin: normalizedBase,
             referer: `${normalizedBase}/`,
-            warmupPath: "/",
+            warmupPaths: ["/", "/anime-terbaru"],
             headersExtra: {
                 "Sec-Fetch-Site": "same-origin",
                 "Sec-Fetch-Mode": "navigate",
                 "Sec-Fetch-Dest": "document",
             },
+            rateLimit: {
+                maxConcurrent: 2,
+                intervalMs: 900,
+                jitterMs: 400,
+            },
+            browserFallback: {
+                enabled: true,
+            },
+            label: "otakudesu",
         };
         super(baseUrl, baseUrlPath, httpOptions);
     }
@@ -171,8 +180,9 @@ class OtakudesuParser extends OtakudesuParserExtra_1.default {
     }
     parseSearch(q) {
         return this.scrape({
-            path: `?s=${q}&post_type=anime`,
+            path: `?s=${encodeURIComponent(q)}&post_type=anime`,
             initialData: { animeList: [] },
+            requestLabel: `search:${q}`,
         }, async ($, data) => {
             const animeElements = $("ul.chivsrc li").toArray();
             animeElements.forEach((animeElement) => {

--- a/dist/anims/samehadaku/parsers/SamehadakuParser.js
+++ b/dist/anims/samehadaku/parsers/SamehadakuParser.js
@@ -12,12 +12,21 @@ class SamehadakuParser extends SamehadakuParserExtra_1.default {
         const httpOptions = {
             origin: normalizedBase,
             referer: `${normalizedBase}/`,
-            warmupPath: "/",
+            warmupPaths: ["/", "/anime-terbaru"],
             headersExtra: {
                 "Sec-Fetch-Site": "same-origin",
                 "Sec-Fetch-Mode": "navigate",
                 "Sec-Fetch-Dest": "document",
             },
+            rateLimit: {
+                maxConcurrent: 1,
+                intervalMs: 1_500,
+                jitterMs: 600,
+            },
+            browserFallback: {
+                enabled: true,
+            },
+            label: "samehadaku",
         };
         super(baseUrl, baseUrlPath, httpOptions);
     }

--- a/dist/configs/animeConfig.js
+++ b/dist/configs/animeConfig.js
@@ -1,5 +1,16 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+const boolFromEnv = (value, defaultValue) => {
+    if (value === undefined)
+        return defaultValue;
+    return ["1", "true", "yes", "on"].includes(value.toLowerCase());
+};
+const numFromEnv = (value, defaultValue) => {
+    if (value === undefined)
+        return defaultValue;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : defaultValue;
+};
 const animeConfig = {
     PORT: 3001,
     baseUrl: {
@@ -7,7 +18,19 @@ const animeConfig = {
         samehadaku: "https://v1.samehadaku.how",
     },
     scraper: {
-        respectRobotsTxt: true,
+        respectRobotsTxt: boolFromEnv(process.env.SCRAPER_RESPECT_ROBOTS, true),
+        defaultRateLimit: {
+            jitterMs: numFromEnv(process.env.SCRAPER_RATE_LIMIT_JITTER_MS, 350),
+        },
+        browserFallback: {
+            enabled: boolFromEnv(process.env.SCRAPER_BROWSER_FALLBACK, false),
+            provider: process.env.SCRAPER_BROWSER_PROVIDER ?? "chromium",
+            waitUntil: process.env.SCRAPER_BROWSER_WAIT_UNTIL ?? "domcontentloaded",
+            navigationTimeoutMs: numFromEnv(process.env.SCRAPER_BROWSER_TIMEOUT_MS, 25000),
+            headless: boolFromEnv(process.env.SCRAPER_BROWSER_HEADLESS, true),
+            userAgent: process.env.SCRAPER_BROWSER_UA ??
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+        },
     },
     response: {
         href: true,

--- a/dist/configs/animeConfig.js
+++ b/dist/configs/animeConfig.js
@@ -6,6 +6,9 @@ const animeConfig = {
         otakudesu: "https://otakudesu.best",
         samehadaku: "https://v1.samehadaku.how",
     },
+    scraper: {
+        respectRobotsTxt: true,
+    },
     response: {
         href: true,
         sourceUrl: true,

--- a/dist/middlewares/errorHandler.js
+++ b/dist/middlewares/errorHandler.js
@@ -4,8 +4,42 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = errorHandler;
+const axios_1 = __importDefault(require("axios"));
 const payload_1 = __importDefault(require("../helpers/payload"));
+function resolveTargetUrl(error) {
+    const config = error?.config || {};
+    const baseURL = config.baseURL;
+    const url = config.url;
+    if (url?.startsWith("http"))
+        return url;
+    if (baseURL && url) {
+        try {
+            const resolved = new URL(url, baseURL.endsWith("/") ? baseURL : `${baseURL}/`);
+            return resolved.toString();
+        }
+        catch (err) {
+            return `${baseURL}${url}`;
+        }
+    }
+    return url || baseURL || "";
+}
+function buildAxiosMessage(error) {
+    const status = error?.response?.status;
+    const targetUrl = resolveTargetUrl(error);
+    if (status === 403) {
+        return `Permintaan diblokir oleh sumber upstream (${targetUrl}). Kemungkinan sistem anti-bot mendeteksi aktivitas otomatis.`;
+    }
+    if (status === 429) {
+        return `Sumber upstream (${targetUrl}) meminta jeda (HTTP 429). Silakan coba lagi setelah beberapa saat.`;
+    }
+    return error?.message || "Terjadi kesalahan pada permintaan upstream.";
+}
 function errorHandler(err, req, res, next) {
+    if (axios_1.default.isAxiosError(err)) {
+        const status = err.response?.status ?? 500;
+        const message = buildAxiosMessage(err);
+        return res.status(status).json((0, payload_1.default)(res, { message }));
+    }
     if (typeof err.status === "number") {
         return res.status(err.status).json((0, payload_1.default)(res, { message: err.message }));
     }

--- a/dist/services/browserFetcher.js
+++ b/dist/services/browserFetcher.js
@@ -1,0 +1,115 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.fetchPageWithBrowser = fetchPageWithBrowser;
+exports.shutdownBrowser = shutdownBrowser;
+const animeConfig_1 = __importDefault(require("../configs/animeConfig"));
+const p_queue_1 = __importDefault(require("p-queue"));
+let cachedBrowser = null;
+const browserQueue = new p_queue_1.default({ concurrency: 1 });
+async function loadPlaywright() {
+    try {
+        return await Promise.resolve().then(() => __importStar(require("playwright-core")));
+    }
+    catch (error) {
+        throw new Error("playwright-core tidak ditemukan. Instal dependency ini untuk mengaktifkan browser fallback.");
+    }
+}
+async function ensureBrowser(playwright, provider, headless) {
+    if (cachedBrowser && cachedBrowser.provider === provider && cachedBrowser.headless === headless) {
+        return cachedBrowser.promise;
+    }
+    const launchPromise = playwright[provider].launch({ headless });
+    cachedBrowser = { provider, headless, promise: launchPromise };
+    return launchPromise;
+}
+function buildExtraHeaders(options) {
+    const headers = {};
+    if (options.headers) {
+        for (const [key, value] of Object.entries(options.headers)) {
+            if (typeof value === "string" && value.trim()) {
+                headers[key] = value;
+            }
+        }
+    }
+    if (options.referer) {
+        headers["Referer"] = options.referer;
+    }
+    return headers;
+}
+async function fetchPageWithBrowser(options) {
+    const globalConfig = animeConfig_1.default.scraper?.browserFallback;
+    if (!globalConfig?.enabled) {
+        throw new Error("Browser fallback dimatikan melalui konfigurasi.");
+    }
+    const provider = (globalConfig.provider ?? "chromium");
+    const headless = options.headless ?? globalConfig.headless ?? true;
+    const waitUntil = options.waitUntil ?? globalConfig.waitUntil ?? "domcontentloaded";
+    const timeout = options.timeoutMs ?? globalConfig.navigationTimeoutMs ?? 25_000;
+    const userAgent = options.userAgent ?? globalConfig.userAgent;
+    const result = (await browserQueue.add(async () => {
+        const playwright = await loadPlaywright();
+        const browser = await ensureBrowser(playwright, provider, headless);
+        const context = await browser.newContext({
+            userAgent,
+        });
+        const extraHeaders = buildExtraHeaders(options);
+        if (Object.keys(extraHeaders).length > 0) {
+            await context.setExtraHTTPHeaders(extraHeaders);
+        }
+        const page = await context.newPage();
+        let html;
+        try {
+            await page.goto(options.url, {
+                waitUntil,
+                timeout,
+                referer: options.referer,
+            });
+            await page.waitForTimeout(250 + Math.random() * 400);
+            html = await page.content();
+        }
+        finally {
+            await context.close().catch(() => undefined);
+        }
+        return html;
+    }));
+    return result;
+}
+async function shutdownBrowser() {
+    if (!cachedBrowser)
+        return;
+    try {
+        const browser = await cachedBrowser.promise;
+        await browser.close();
+    }
+    catch (error) {
+    }
+    finally {
+        cachedBrowser = null;
+    }
+}

--- a/dist/services/dataFetcher.js
+++ b/dist/services/dataFetcher.js
@@ -1,65 +1,200 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.wajikFetch = wajikFetch;
+exports.createFetcher = createFetcher;
+exports.getOrCreateFetcher = getOrCreateFetcher;
+exports.warmup = warmup;
 exports.getFinalUrl = getFinalUrl;
 exports.getFinalUrls = getFinalUrls;
-const axios_1 = __importDefault(require("axios"));
-const userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36";
-async function wajikFetch(url, ref, axiosConfig, callback) {
-    const response = await (0, axios_1.default)(url, {
-        ...axiosConfig,
-        headers: {
-            "User-Agent": userAgent,
-            Referer: ref,
-            ...axiosConfig?.headers,
+const axios_1 = __importStar(require("axios"));
+const axios_retry_1 = __importDefault(require("axios-retry"));
+const node_crypto_1 = __importDefault(require("node:crypto"));
+const tough_cookie_1 = require("tough-cookie");
+const http_1 = require("http-cookie-agent/http");
+const USER_AGENTS = [
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_5_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
+];
+const fetcherCache = new Map();
+function createCookieJar(existing) {
+    if (existing)
+        return existing;
+    return new tough_cookie_1.CookieJar();
+}
+function pickUserAgent(seed) {
+    const hash = node_crypto_1.default
+        .createHash("sha256")
+        .update(seed ?? `${Date.now()}-${Math.random()}`)
+        .digest();
+    const index = hash[0] % USER_AGENTS.length;
+    return USER_AGENTS[index];
+}
+function buildDefaultHeaders(options, ua) {
+    const headers = {
+        "User-Agent": ua,
+        Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+        "Accept-Language": "id-ID,id;q=0.9,en-US;q=0.8,en;q=0.7",
+        "Accept-Encoding": "gzip, deflate, br",
+        Connection: "keep-alive",
+        DNT: "1",
+        "Upgrade-Insecure-Requests": "1",
+        Pragma: "no-cache",
+        "Cache-Control": "no-cache",
+    };
+    if (options.origin) {
+        headers["Origin"] = options.origin;
+    }
+    if (options.referer) {
+        headers["Referer"] = options.referer;
+    }
+    if (options.headersExtra) {
+        Object.assign(headers, options.headersExtra);
+    }
+    return headers;
+}
+function createFetcher(options = {}) {
+    const jar = createCookieJar(options.jar);
+    const httpAgent = new http_1.HttpCookieAgent({
+        cookies: { jar },
+        keepAlive: true,
+    });
+    const httpsAgent = new http_1.HttpsCookieAgent({
+        cookies: { jar },
+        keepAlive: true,
+    });
+    const client = axios_1.default.create({
+        baseURL: options.baseURL,
+        timeout: options.timeoutMs ?? 15_000,
+        httpAgent,
+        httpsAgent,
+        withCredentials: true,
+    });
+    (0, axios_retry_1.default)(client, {
+        retries: 3,
+        retryDelay: (retryCount) => {
+            const base = axios_retry_1.default.exponentialDelay(retryCount);
+            const jitter = Math.floor(Math.random() * 400);
+            return base + jitter;
+        },
+        shouldResetTimeout: true,
+        retryCondition: (error) => {
+            if (!axios_retry_1.default.isNetworkOrIdempotentRequestError(error)) {
+                const status = error?.response?.status;
+                if (!status)
+                    return false;
+                return [403, 408, 425, 429, 500, 502, 503, 504].includes(status);
+            }
+            return true;
         },
     });
-    if (callback)
-        callback(response);
-    const data = response.data;
-    return data;
+    client.interceptors.request.use((config) => {
+        const ua = pickUserAgent(options.baseURL ?? options.origin ?? options.referer);
+        const existingHeaders = config.headers instanceof axios_1.AxiosHeaders
+            ? config.headers.toJSON()
+            : axios_1.AxiosHeaders.from(config.headers ?? {}).toJSON();
+        const mergedHeaders = {
+            ...buildDefaultHeaders(options, ua),
+            ...existingHeaders,
+        };
+        config.headers = axios_1.AxiosHeaders.from(mergedHeaders);
+        if (config.headers) {
+            if (!("Accept-Encoding" in config.headers)) {
+                config.headers["Accept-Encoding"] = "gzip, deflate, br";
+            }
+        }
+        return config;
+    });
+    return { client, jar };
+}
+function resolveFetcherKey(options) {
+    const base = options.baseURL ?? options.origin ?? options.referer ?? "default";
+    return base;
+}
+function getOrCreateFetcher(options = {}) {
+    const key = resolveFetcherKey(options);
+    const existing = fetcherCache.get(key);
+    if (existing)
+        return existing;
+    const context = createFetcher(options);
+    fetcherCache.set(key, context);
+    return context;
+}
+async function warmup(client, url) {
+    try {
+        await client.get(url, {
+            responseType: "text",
+            transformResponse: (data) => data,
+        });
+    }
+    catch (error) {
+    }
 }
 async function getFinalUrl(url, ref, axiosConfig) {
-    const response = await axios_1.default.head(url, {
+    const { client } = getOrCreateFetcher({
+        baseURL: ref,
+        origin: ref,
+        referer: ref.endsWith("/") ? ref : `${ref}/`,
+    });
+    const response = await client.head(url, {
         ...axiosConfig,
-        headers: {
-            "User-Agent": userAgent,
-            Referer: ref,
-            ...axiosConfig?.headers,
-        },
         maxRedirects: 0,
-        validateStatus: function (status) {
-            return status >= 200 && status < 400;
-        },
+        validateStatus: (status) => status >= 200 && status < 400,
     });
     const location = response.headers["location"];
-    if (location)
-        return location;
+    if (location) {
+        try {
+            const resolved = new URL(location, url);
+            return resolved.toString();
+        }
+        catch (error) {
+            return location;
+        }
+    }
     return url;
 }
 async function getFinalUrls(urls, ref, config) {
-    const { retries = 3, delay = 1000 } = config.retryConfig || {};
-    const retryRequest = async (url) => {
-        for (let attempt = 1; attempt <= retries; attempt++) {
+    const { retries = 3, delay = 1_000 } = config.retryConfig || {};
+    const retryRequest = async (targetUrl) => {
+        for (let attempt = 1; attempt <= retries; attempt += 1) {
             try {
-                return await getFinalUrl(url, ref, config.axiosConfig);
+                return await getFinalUrl(targetUrl, ref, config.axiosConfig);
             }
             catch (error) {
                 if (attempt === retries)
                     throw error;
-                await new Promise((resolve) => setTimeout(resolve, delay));
+                await new Promise((resolve) => setTimeout(resolve, delay + Math.random() * 200));
             }
         }
-    };
-    const requests = urls.map((url) => retryRequest(url));
-    const responses = await Promise.allSettled(requests);
-    const results = responses.map((response) => {
-        if (response.status === "fulfilled")
-            return response.value;
         return "";
-    });
-    return results;
+    };
+    const requests = urls.map((targetUrl) => retryRequest(targetUrl));
+    const responses = await Promise.allSettled(requests);
+    return responses.map((response) => (response.status === "fulfilled" ? response.value : ""));
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,8 @@
         "express": "^4.21.1",
         "http-cookie-agent": "^6.0.3",
         "lru-cache": "^11.0.1",
+        "p-queue": "^7.4.1",
+        "playwright-core": "^1.45.0",
         "tough-cookie": "^4.1.4"
       },
       "devDependencies": {
@@ -1515,6 +1517,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
     "node_modules/expand-tilde": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
@@ -2979,6 +2987,34 @@
         "wrappy": "1"
       }
     },
+    "node_modules/p-queue": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.4.1.tgz",
+      "integrity": "sha512-vRpMXmIkYF2/1hLBKisKeVYJZ8S2tZ0zEAmIJgdVKP2nq0nh4qCdf8bgw+ZgKrkh71AOCaqzwbJJk1WtdcF3VA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
+      "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -3147,6 +3183,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
+      "integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/plimit-lit": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,16 +10,20 @@
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.6",
+        "axios-retry": "^4.5.0",
         "cheerio": "1.0.0-rc.12",
         "cors": "^2.8.5",
         "express": "^4.21.1",
-        "lru-cache": "^11.0.1"
+        "http-cookie-agent": "^6.0.3",
+        "lru-cache": "^11.0.1",
+        "tough-cookie": "^4.1.4"
       },
       "devDependencies": {
         "@hasura/ts-node-dev": "^2.1.0",
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
         "@types/node": "^22.8.6",
+        "@types/tough-cookie": "^4.0.5",
         "gulp": "^5.0.0",
         "gulp-csso": "^4.0.1",
         "gulp-html-minifier-terser": "^7.1.0",
@@ -478,6 +482,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -513,6 +524,15 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ansi-colors": {
@@ -690,6 +710,18 @@
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios-retry": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.5.0.tgz",
+      "integrity": "sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-retry-allowed": "^2.2.0"
+      },
+      "peerDependencies": {
+        "axios": "0.x || 1.x"
       }
     },
     "node_modules/bach": {
@@ -2243,6 +2275,30 @@
         "entities": "^4.4.0"
       }
     },
+    "node_modules/http-cookie-agent": {
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-6.0.8.tgz",
+      "integrity": "sha512-qnYh3yLSr2jBsTYkw11elq+T361uKAJaZ2dR4cfYZChw1dt9uL5t3zSUwehoqqVb4oldk1BpkXKm2oat8zV+oA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/3846masa"
+      },
+      "peerDependencies": {
+        "tough-cookie": "^4.0.0 || ^5.0.0",
+        "undici": "^5.11.0 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "undici": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -2469,6 +2525,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-unc-path": {
@@ -3127,6 +3195,27 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/qs": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
@@ -3140,6 +3229,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
     },
     "node_modules/queue-lit": {
       "version": "1.5.2",
@@ -3287,6 +3382,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -3828,6 +3929,21 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -4012,12 +4128,31 @@
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true
     },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/node": "^22.8.6",
+    "@types/tough-cookie": "^4.0.5",
     "gulp": "^5.0.0",
     "gulp-csso": "^4.0.1",
     "gulp-html-minifier-terser": "^7.1.0",
@@ -30,9 +31,12 @@
   },
   "dependencies": {
     "axios": "^1.7.6",
+    "axios-retry": "^4.5.0",
     "cheerio": "1.0.0-rc.12",
     "cors": "^2.8.5",
     "express": "^4.21.1",
-    "lru-cache": "^11.0.1"
+    "http-cookie-agent": "^6.0.3",
+    "lru-cache": "^11.0.1",
+    "tough-cookie": "^4.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "express": "^4.21.1",
     "http-cookie-agent": "^6.0.3",
     "lru-cache": "^11.0.1",
+    "p-queue": "^7.4.1",
+    "playwright-core": "^1.45.0",
     "tough-cookie": "^4.1.4"
   }
 }

--- a/src/anims/otakudesu/parsers/OtakudesuParser.ts
+++ b/src/anims/otakudesu/parsers/OtakudesuParser.ts
@@ -11,12 +11,21 @@ export default class OtakudesuParser extends OtakudesuParserExtra {
     const httpOptions: AnimeScraperHttpOptions = {
       origin: normalizedBase,
       referer: `${normalizedBase}/`,
-      warmupPath: "/",
+      warmupPaths: ["/", "/anime-terbaru"],
       headersExtra: {
         "Sec-Fetch-Site": "same-origin",
         "Sec-Fetch-Mode": "navigate",
         "Sec-Fetch-Dest": "document",
       },
+      rateLimit: {
+        maxConcurrent: 2,
+        intervalMs: 900,
+        jitterMs: 400,
+      },
+      browserFallback: {
+        enabled: true,
+      },
+      label: "otakudesu",
     };
 
     super(baseUrl, baseUrlPath, httpOptions);
@@ -240,8 +249,9 @@ export default class OtakudesuParser extends OtakudesuParserExtra {
   parseSearch(q: string): Promise<IOP.Search> {
     return this.scrape<IOP.Search>(
       {
-        path: `?s=${q}&post_type=anime`,
+        path: `?s=${encodeURIComponent(q)}&post_type=anime`,
         initialData: { animeList: [] },
+        requestLabel: `search:${q}`,
       },
       async ($, data) => {
         const animeElements = $("ul.chivsrc li").toArray();

--- a/src/anims/samehadaku/parsers/SamehadakuParser.ts
+++ b/src/anims/samehadaku/parsers/SamehadakuParser.ts
@@ -12,12 +12,21 @@ export default class SamehadakuParser extends SamehadakuParserExtra {
     const httpOptions: AnimeScraperHttpOptions = {
       origin: normalizedBase,
       referer: `${normalizedBase}/`,
-      warmupPath: "/",
+      warmupPaths: ["/", "/anime-terbaru"],
       headersExtra: {
         "Sec-Fetch-Site": "same-origin",
         "Sec-Fetch-Mode": "navigate",
         "Sec-Fetch-Dest": "document",
       },
+      rateLimit: {
+        maxConcurrent: 1,
+        intervalMs: 1_500,
+        jitterMs: 600,
+      },
+      browserFallback: {
+        enabled: true,
+      },
+      label: "samehadaku",
     };
 
     super(baseUrl, baseUrlPath, httpOptions);

--- a/src/configs/animeConfig.ts
+++ b/src/configs/animeConfig.ts
@@ -1,3 +1,14 @@
+const boolFromEnv = (value: string | undefined, defaultValue: boolean): boolean => {
+  if (value === undefined) return defaultValue;
+  return ["1", "true", "yes", "on"].includes(value.toLowerCase());
+};
+
+const numFromEnv = (value: string | undefined, defaultValue: number): number => {
+  if (value === undefined) return defaultValue;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : defaultValue;
+};
+
 const animeConfig = {
   PORT: 3001,
 
@@ -7,7 +18,24 @@ const animeConfig = {
   },
 
   scraper: {
-    respectRobotsTxt: true,
+    respectRobotsTxt: boolFromEnv(process.env.SCRAPER_RESPECT_ROBOTS, true),
+    defaultRateLimit: {
+      jitterMs: numFromEnv(process.env.SCRAPER_RATE_LIMIT_JITTER_MS, 350),
+    },
+    browserFallback: {
+      enabled: boolFromEnv(process.env.SCRAPER_BROWSER_FALLBACK, false),
+      provider: (process.env.SCRAPER_BROWSER_PROVIDER as "chromium" | "firefox" | "webkit" | undefined) ?? "chromium",
+      waitUntil: (process.env.SCRAPER_BROWSER_WAIT_UNTIL as
+        | "load"
+        | "domcontentloaded"
+        | "networkidle"
+        | undefined) ?? "domcontentloaded",
+      navigationTimeoutMs: numFromEnv(process.env.SCRAPER_BROWSER_TIMEOUT_MS, 25000),
+      headless: boolFromEnv(process.env.SCRAPER_BROWSER_HEADLESS, true),
+      userAgent:
+        process.env.SCRAPER_BROWSER_UA ??
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+    },
   },
 
   response: {

--- a/src/configs/animeConfig.ts
+++ b/src/configs/animeConfig.ts
@@ -6,6 +6,10 @@ const animeConfig = {
     samehadaku: "https://v1.samehadaku.how",
   },
 
+  scraper: {
+    respectRobotsTxt: true,
+  },
+
   response: {
     /* ngebalikin respon href biar gampang nyari ref idnya contoh {"href": "/otakudesu/anime/animeId"} value = false akan mengurangi ukuran response <> up to 30% */
     href: true,

--- a/src/middlewares/errorHandler.ts
+++ b/src/middlewares/errorHandler.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import type { NextFunction, Request, Response } from "express";
 import generatePayload from "@helpers/payload";
+import type { UpstreamDiagnostic } from "@services/dataFetcher";
 
 function resolveTargetUrl(error: any): string {
   const config = error?.config || {};
@@ -20,12 +21,39 @@ function resolveTargetUrl(error: any): string {
   return url || baseURL || "";
 }
 
+function describeUpstreamBlock(targetUrl: string, upstream?: UpstreamDiagnostic): string {
+  const provider = upstream?.provider && upstream.provider !== "unknown"
+    ? upstream.provider
+    : "sumber upstream";
+  const context = upstream?.requestLabel ? ` [request: ${upstream.requestLabel}]` : "";
+
+  switch (upstream?.reason) {
+    case "browser_challenge":
+      return `Permintaan memerlukan verifikasi browser oleh ${provider} (${targetUrl}). Aktifkan SCRAPER_BROWSER_FALLBACK=true untuk menggunakan fallback Playwright atau coba lagi secara manual.${context}`;
+    case "bot_block":
+      return `Permintaan diblokir oleh ${provider} (${targetUrl}). Kurangi frekuensi permintaan, pastikan header sudah lengkap, atau gunakan fallback browser bila diizinkan.${context}`;
+    case "geo_block":
+      return `Akses ke ${targetUrl} dibatasi berdasarkan lokasi oleh ${provider}. Layanan tidak dapat meneruskan permintaan ini.${context}`;
+    case "rate_limited":
+      return `Sumber upstream (${targetUrl}) menerapkan rate limit. Sistem sudah mencoba ulang otomatis, mohon beri jeda sebelum mencoba kembali.${context}`;
+    case "maintenance":
+      return `Sumber upstream (${targetUrl}) sedang tidak stabil atau dalam perawatan (HTTP ${upstream?.status ?? 503}). Silakan coba lagi nanti.${context}`;
+    case "unauthorized":
+      return `Permintaan ke ${targetUrl} memerlukan otorisasi tambahan dari ${provider}. Endpoint ini tidak dapat diakses tanpa kredensial yang valid.${context}`;
+    case "network":
+      return `Permintaan ke ${targetUrl} gagal karena kendala jaringan. Mohon periksa koneksi dan coba ulang.${context}`;
+    default:
+      return `Permintaan ke ${targetUrl} ditolak oleh sumber upstream.${context}`;
+  }
+}
+
 function buildAxiosMessage(error: any): string {
   const status = error?.response?.status;
   const targetUrl = resolveTargetUrl(error);
+  const upstream: UpstreamDiagnostic | undefined = error?.upstream;
 
-  if (status === 403) {
-    return `Permintaan diblokir oleh sumber upstream (${targetUrl}). Kemungkinan sistem anti-bot mendeteksi aktivitas otomatis.`;
+  if (upstream) {
+    return describeUpstreamBlock(targetUrl, upstream);
   }
 
   if (status === 429) {

--- a/src/middlewares/errorHandler.ts
+++ b/src/middlewares/errorHandler.ts
@@ -1,7 +1,48 @@
+import axios from "axios";
 import type { NextFunction, Request, Response } from "express";
 import generatePayload from "@helpers/payload";
 
+function resolveTargetUrl(error: any): string {
+  const config = error?.config || {};
+  const baseURL: string | undefined = config.baseURL;
+  const url: string | undefined = config.url;
+
+  if (url?.startsWith("http")) return url;
+  if (baseURL && url) {
+    try {
+      const resolved = new URL(url, baseURL.endsWith("/") ? baseURL : `${baseURL}/`);
+      return resolved.toString();
+    } catch (err) {
+      return `${baseURL}${url}`;
+    }
+  }
+
+  return url || baseURL || "";
+}
+
+function buildAxiosMessage(error: any): string {
+  const status = error?.response?.status;
+  const targetUrl = resolveTargetUrl(error);
+
+  if (status === 403) {
+    return `Permintaan diblokir oleh sumber upstream (${targetUrl}). Kemungkinan sistem anti-bot mendeteksi aktivitas otomatis.`;
+  }
+
+  if (status === 429) {
+    return `Sumber upstream (${targetUrl}) meminta jeda (HTTP 429). Silakan coba lagi setelah beberapa saat.`;
+  }
+
+  return error?.message || "Terjadi kesalahan pada permintaan upstream.";
+}
+
 export default function errorHandler(err: any, req: Request, res: Response, next: NextFunction) {
+  if (axios.isAxiosError(err)) {
+    const status = err.response?.status ?? 500;
+    const message = buildAxiosMessage(err);
+
+    return res.status(status).json(generatePayload(res, { message }));
+  }
+
   if (typeof err.status === "number") {
     return res.status(err.status).json(generatePayload(res, { message: err.message }));
   }

--- a/src/services/browserFetcher.ts
+++ b/src/services/browserFetcher.ts
@@ -1,0 +1,126 @@
+import animeConfig from "@configs/animeConfig";
+import PQueue from "p-queue";
+
+type PlaywrightModule = typeof import("playwright-core");
+type BrowserTypeName = "chromium" | "firefox" | "webkit";
+
+type Browser = import("playwright-core").Browser;
+
+export interface BrowserFetchOptions {
+  url: string;
+  referer?: string;
+  waitUntil?: "load" | "domcontentloaded" | "networkidle";
+  timeoutMs?: number;
+  headers?: Record<string, string>;
+  userAgent?: string;
+  headless?: boolean;
+  label?: string;
+}
+
+interface BrowserCacheEntry {
+  provider: BrowserTypeName;
+  headless: boolean;
+  promise: Promise<Browser>;
+}
+
+let cachedBrowser: BrowserCacheEntry | null = null;
+const browserQueue = new PQueue({ concurrency: 1 });
+
+async function loadPlaywright(): Promise<PlaywrightModule> {
+  try {
+    return await import("playwright-core");
+  } catch (error) {
+    throw new Error(
+      "playwright-core tidak ditemukan. Instal dependency ini untuk mengaktifkan browser fallback."
+    );
+  }
+}
+
+async function ensureBrowser(
+  playwright: PlaywrightModule,
+  provider: BrowserTypeName,
+  headless: boolean
+): Promise<Browser> {
+  if (cachedBrowser && cachedBrowser.provider === provider && cachedBrowser.headless === headless) {
+    return cachedBrowser.promise;
+  }
+
+  const launchPromise = playwright[provider].launch({ headless });
+  cachedBrowser = { provider, headless, promise: launchPromise };
+  return launchPromise;
+}
+
+function buildExtraHeaders(options: BrowserFetchOptions): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (options.headers) {
+    for (const [key, value] of Object.entries(options.headers)) {
+      if (typeof value === "string" && value.trim()) {
+        headers[key] = value;
+      }
+    }
+  }
+
+  if (options.referer) {
+    headers["Referer"] = options.referer;
+  }
+
+  return headers;
+}
+
+export async function fetchPageWithBrowser(options: BrowserFetchOptions): Promise<string | undefined> {
+  const globalConfig = animeConfig.scraper?.browserFallback;
+  if (!globalConfig?.enabled) {
+    throw new Error("Browser fallback dimatikan melalui konfigurasi.");
+  }
+
+  const provider = (globalConfig.provider ?? "chromium") as BrowserTypeName;
+  const headless = options.headless ?? globalConfig.headless ?? true;
+  const waitUntil = options.waitUntil ?? globalConfig.waitUntil ?? "domcontentloaded";
+  const timeout = options.timeoutMs ?? globalConfig.navigationTimeoutMs ?? 25_000;
+  const userAgent = options.userAgent ?? globalConfig.userAgent;
+
+  const result = (await browserQueue.add(async (): Promise<string | undefined> => {
+    const playwright = await loadPlaywright();
+    const browser = await ensureBrowser(playwright, provider, headless);
+
+    const context = await browser.newContext({
+      userAgent,
+    });
+
+    const extraHeaders = buildExtraHeaders(options);
+    if (Object.keys(extraHeaders).length > 0) {
+      await context.setExtraHTTPHeaders(extraHeaders);
+    }
+
+    const page = await context.newPage();
+    let html: string | undefined;
+
+    try {
+      await page.goto(options.url, {
+        waitUntil,
+        timeout,
+        referer: options.referer,
+      });
+
+      await page.waitForTimeout(250 + Math.random() * 400);
+      html = await page.content();
+    } finally {
+      await context.close().catch(() => undefined);
+    }
+    return html;
+  })) as string | undefined;
+
+  return result;
+}
+
+export async function shutdownBrowser(): Promise<void> {
+  if (!cachedBrowser) return;
+  try {
+    const browser = await cachedBrowser.promise;
+    await browser.close();
+  } catch (error) {
+    // ignore shutdown errors
+  } finally {
+    cachedBrowser = null;
+  }
+}

--- a/src/services/dataFetcher.ts
+++ b/src/services/dataFetcher.ts
@@ -1,51 +1,202 @@
-import axios, { type AxiosResponse, type AxiosRequestConfig } from "axios";
+import axios, {
+  AxiosError,
+  type AxiosInstance,
+  type AxiosRequestConfig,
+  AxiosHeaders,
+} from "axios";
+import axiosRetry from "axios-retry";
+import crypto from "node:crypto";
+import { CookieJar } from "tough-cookie";
+import { HttpCookieAgent, HttpsCookieAgent } from "http-cookie-agent/http";
 
-const userAgent =
-  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36";
+const USER_AGENTS: readonly string[] = [
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_5_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
+  "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
+];
 
-export async function wajikFetch(
-  url: string,
-  ref: string,
-  axiosConfig?: AxiosRequestConfig<any>,
-  callback?: (response: AxiosResponse) => void
-): Promise<any> {
-  const response = await axios(url, {
-    ...axiosConfig,
-    headers: {
-      "User-Agent": userAgent,
-      Referer: ref,
-      ...axiosConfig?.headers,
+export interface FetcherOptions {
+  baseURL?: string;
+  origin?: string;
+  referer?: string;
+  headersExtra?: Record<string, string>;
+  timeoutMs?: number;
+  jar?: CookieJar;
+}
+
+export interface FetcherContext {
+  client: AxiosInstance;
+  jar: CookieJar;
+}
+
+const fetcherCache = new Map<string, FetcherContext>();
+
+function createCookieJar(existing?: CookieJar): CookieJar {
+  if (existing) return existing;
+
+  return new CookieJar();
+}
+
+function pickUserAgent(seed?: string): string {
+  const hash = crypto
+    .createHash("sha256")
+    .update(seed ?? `${Date.now()}-${Math.random()}`)
+    .digest();
+  const index = hash[0] % USER_AGENTS.length;
+
+  return USER_AGENTS[index];
+}
+
+function buildDefaultHeaders(options: FetcherOptions, ua: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    "User-Agent": ua,
+    Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+    "Accept-Language": "id-ID,id;q=0.9,en-US;q=0.8,en;q=0.7",
+    "Accept-Encoding": "gzip, deflate, br",
+    Connection: "keep-alive",
+    DNT: "1",
+    "Upgrade-Insecure-Requests": "1",
+    Pragma: "no-cache",
+    "Cache-Control": "no-cache",
+  };
+
+  if (options.origin) {
+    headers["Origin"] = options.origin;
+  }
+
+  if (options.referer) {
+    headers["Referer"] = options.referer;
+  }
+
+  if (options.headersExtra) {
+    Object.assign(headers, options.headersExtra);
+  }
+
+  return headers;
+}
+
+export function createFetcher(options: FetcherOptions = {}): FetcherContext {
+  const jar = createCookieJar(options.jar);
+  const httpAgent = new HttpCookieAgent({
+    cookies: { jar },
+    keepAlive: true,
+  });
+  const httpsAgent = new HttpsCookieAgent({
+    cookies: { jar },
+    keepAlive: true,
+  });
+
+  const client = axios.create({
+    baseURL: options.baseURL,
+    timeout: options.timeoutMs ?? 15_000,
+    httpAgent,
+    httpsAgent,
+    withCredentials: true,
+  });
+
+  axiosRetry(client, {
+    retries: 3,
+    retryDelay: (retryCount) => {
+      const base = axiosRetry.exponentialDelay(retryCount);
+      const jitter = Math.floor(Math.random() * 400);
+
+      return base + jitter;
+    },
+    shouldResetTimeout: true,
+    retryCondition: (error) => {
+      if (!axiosRetry.isNetworkOrIdempotentRequestError(error)) {
+        const status = (error as AxiosError)?.response?.status;
+        if (!status) return false;
+
+        return [403, 408, 425, 429, 500, 502, 503, 504].includes(status);
+      }
+
+      return true;
     },
   });
 
-  if (callback) callback(response);
+  client.interceptors.request.use((config) => {
+    const ua = pickUserAgent(options.baseURL ?? options.origin ?? options.referer);
+    const existingHeaders =
+      config.headers instanceof AxiosHeaders
+        ? config.headers.toJSON()
+        : AxiosHeaders.from(config.headers ?? {}).toJSON();
 
-  const data = response.data;
+    const mergedHeaders = {
+      ...buildDefaultHeaders(options, ua),
+      ...existingHeaders,
+    };
 
-  return data;
+    config.headers = AxiosHeaders.from(mergedHeaders);
+
+    if (config.headers) {
+      if (!("Accept-Encoding" in config.headers)) {
+        config.headers["Accept-Encoding"] = "gzip, deflate, br";
+      }
+    }
+
+    return config;
+  });
+
+  return { client, jar };
+}
+
+function resolveFetcherKey(options: FetcherOptions): string {
+  const base = options.baseURL ?? options.origin ?? options.referer ?? "default";
+
+  return base;
+}
+
+export function getOrCreateFetcher(options: FetcherOptions = {}): FetcherContext {
+  const key = resolveFetcherKey(options);
+  const existing = fetcherCache.get(key);
+  if (existing) return existing;
+
+  const context = createFetcher(options);
+  fetcherCache.set(key, context);
+
+  return context;
+}
+
+export async function warmup(client: AxiosInstance, url: string): Promise<void> {
+  try {
+    await client.get(url, {
+      responseType: "text",
+      transformResponse: (data) => data,
+    });
+  } catch (error) {
+    // Ignore warmup failures – downstream requests will surface real errors
+  }
 }
 
 export async function getFinalUrl(
   url: string,
   ref: string,
   axiosConfig?: AxiosRequestConfig<any>
-): Promise<any> {
-  const response = await axios.head(url, {
+): Promise<string> {
+  const { client } = getOrCreateFetcher({
+    baseURL: ref,
+    origin: ref,
+    referer: ref.endsWith("/") ? ref : `${ref}/`,
+  });
+
+  const response = await client.head(url, {
     ...axiosConfig,
-    headers: {
-      "User-Agent": userAgent,
-      Referer: ref,
-      ...axiosConfig?.headers,
-    },
     maxRedirects: 0,
-    validateStatus: function (status) {
-      return status >= 200 && status < 400;
-    },
+    validateStatus: (status) => status >= 200 && status < 400,
   });
 
   const location = response.headers["location"];
 
-  if (location) return location;
+  if (location) {
+    try {
+      const resolved = new URL(location, url);
+      return resolved.toString();
+    } catch (error) {
+      return location;
+    }
+  }
 
   return url;
 }
@@ -60,29 +211,25 @@ export async function getFinalUrls(
       delay?: number;
     };
   }
-): Promise<any[]> {
-  const { retries = 3, delay = 1000 } = config.retryConfig || {};
+): Promise<string[]> {
+  const { retries = 3, delay = 1_000 } = config.retryConfig || {};
 
-  const retryRequest = async (url: string): Promise<any> => {
-    for (let attempt = 1; attempt <= retries; attempt++) {
+  const retryRequest = async (targetUrl: string): Promise<string> => {
+    for (let attempt = 1; attempt <= retries; attempt += 1) {
       try {
-        return await getFinalUrl(url, ref, config.axiosConfig);
+        return await getFinalUrl(targetUrl, ref, config.axiosConfig);
       } catch (error) {
         if (attempt === retries) throw error;
 
-        await new Promise((resolve) => setTimeout(resolve, delay));
+        await new Promise((resolve) => setTimeout(resolve, delay + Math.random() * 200));
       }
     }
-  };
-
-  const requests = urls.map((url) => retryRequest(url));
-  const responses = await Promise.allSettled(requests);
-
-  const results = responses.map((response) => {
-    if (response.status === "fulfilled") return response.value;
 
     return "";
-  });
+  };
 
-  return results;
+  const requests = urls.map((targetUrl) => retryRequest(targetUrl));
+  const responses = await Promise.allSettled(requests);
+
+  return responses.map((response) => (response.status === "fulfilled" ? response.value : ""));
 }


### PR DESCRIPTION
## Summary
- add a hardened HTTP fetcher with cookie jar support, retry/backoff, and realistic browser headers
- update the AnimeScraper base to reuse the new client with optional warmup and robots.txt awareness
- refresh Samehadaku and Otakudesu adapters plus error handling to use the new client and surface friendlier upstream failures

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcb24229dc832ca7428306ee4baacf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Optional browser-based fallback to retrieve pages when regular requests are blocked.
  - Exposed scraper configuration (robots respect, rate-limit jitter, browser-fallback settings) via environment.
  - Improved link resolution with cookie-aware fetches, retries, and rotating user-agents.

- Bug Fixes
  - Fewer failures resolving final URLs and iframe sources.
  - Clearer, more informative messages for upstream blocks and rate-limits.

- Refactor
  - Centralized HTTP/fetcher layer with warmup, robots enforcement, and request queuing.

- Chores
  - Added dependencies for retries, cookie agents, queueing, and browser fetching; updated types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->